### PR TITLE
[DABOM-353] 2차 컴포넌트 개선

### DIFF
--- a/apps/service/src/components/common/Header.tsx
+++ b/apps/service/src/components/common/Header.tsx
@@ -2,20 +2,31 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 
-import { ChevronIcon, Logo, cn } from '@shared';
+import { ChevronIcon, Logo, NotificationIcon, cn } from '@shared';
 
 interface HeaderProps {
   isBackVisible?: boolean;
+  isNotiVisible?: boolean;
   onBackClick?: () => void;
+  onNotiClick?: () => void;
   className?: string;
 }
 
-const Header = ({ isBackVisible = true, className, onBackClick }: HeaderProps) => {
+const Header = ({
+  isBackVisible,
+  isNotiVisible,
+  onBackClick,
+  onNotiClick,
+  className,
+}: HeaderProps) => {
   const router = useRouter();
   const pathname = usePathname();
 
   const HIDE_BACK_BTN_PATHS = ['/home', '/notification', '/policy'];
-  const shouldShowBack = isBackVisible && !HIDE_BACK_BTN_PATHS.includes(pathname);
+  const HIDE_NOTI_BTN_PATHS = ['/home', '/notification', '/policy'];
+
+  const shouldShowBack = isBackVisible ?? !HIDE_BACK_BTN_PATHS.includes(pathname);
+  const shouldShowNoti = isNotiVisible ?? !HIDE_NOTI_BTN_PATHS.includes(pathname);
 
   const handleBack = () => {
     if (onBackClick) {
@@ -25,30 +36,49 @@ const Header = ({ isBackVisible = true, className, onBackClick }: HeaderProps) =
     router.back();
   };
 
+  const handleNotiClick = () => {
+    if (onNotiClick) {
+      onNotiClick();
+      return;
+    }
+
+    router.push('/notification');
+  };
+
   return (
     <header
       className={cn(
-        'sticky top-0 z-50 flex h-16 w-full items-center justify-between bg-white shadow-sm transition-all',
+        'sticky top-0 z-50 flex h-16 w-full items-center justify-between px-5',
         className,
       )}
     >
-      <div className="flex w-10 items-center justify-start">
+      <div className="flex items-center justify-center">
         {shouldShowBack && (
           <button
             type="button"
             onClick={handleBack}
-            aria-label="Go back"
-            className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full hover:bg-gray-100 active:bg-gray-200"
+            className="flex cursor-pointer items-center justify-center"
           >
-            <ChevronIcon width={9.5} height={16} />
+            <ChevronIcon width={7} height={12} className="rotate-180" />
           </button>
         )}
       </div>
 
-      <div>
-        <Logo type="default" />
+      <div className="flex items-center justify-center">
+        <Logo type="default" width={69} height={16} />
       </div>
-      <div className="flex w-10 items-center"></div>
+
+      <div className="flex cursor-pointer items-center justify-center">
+        {shouldShowNoti && (
+          <button
+            type="button"
+            onClick={handleNotiClick}
+            className="flex items-center justify-center"
+          >
+            <NotificationIcon width={13} height={16} />
+          </button>
+        )}
+      </div>
     </header>
   );
 };

--- a/apps/service/src/components/common/Header.tsx
+++ b/apps/service/src/components/common/Header.tsx
@@ -57,6 +57,7 @@ const Header = ({
           <button
             type="button"
             onClick={handleBack}
+            aria-label="뒤로 가기"
             className="flex cursor-pointer items-center justify-center"
           >
             <ChevronIcon width={7} height={12} className="rotate-180" />
@@ -68,12 +69,13 @@ const Header = ({
         <Logo type="default" width={69} height={16} />
       </div>
 
-      <div className="flex cursor-pointer items-center justify-center">
+      <div className="flex items-center justify-center">
         {shouldShowNoti && (
           <button
             type="button"
             onClick={handleNotiClick}
-            className="flex items-center justify-center"
+            aria-label="알림 보기"
+            className="flex cursor-pointer items-center justify-center"
           >
             <NotificationIcon width={13} height={16} />
           </button>

--- a/apps/service/src/components/common/NavBar.tsx
+++ b/apps/service/src/components/common/NavBar.tsx
@@ -62,11 +62,7 @@ const NavBar = () => {
 
         <Link
           href="/home"
-          className="absolute top-0 left-1/2 flex h-13 w-13 -translate-x-1/2 items-center justify-center rounded-full"
-          style={{
-            background:
-              'linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), var(--color-brand-dark)',
-          }}
+          className="bg-brand-dark absolute top-0 left-1/2 flex h-13 w-13 -translate-x-1/2 items-center justify-center rounded-full"
         >
           <HomeIcon width={17} height={19} className="text-white" />
         </Link>

--- a/apps/service/src/components/common/NavBar.tsx
+++ b/apps/service/src/components/common/NavBar.tsx
@@ -1,62 +1,72 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-import { DocumentIcon, HomeIcon, NotificationIcon, PersonIcon } from '@icons';
-import { SvgIconProps } from '@mui/material';
+import {
+  ExtensionOutlined as ExtensionIcon,
+  Face as FaceIcon,
+  Home as HomeIcon,
+  PersonOutlined as PersonIcon,
+  SendOutlined as SendMoneyIcon,
+} from '@mui/icons-material';
 
-interface NavItem {
-  label: string;
-  href: string;
-  icon: React.ComponentType<SvgIconProps>;
-}
+const navItems = [
+  { label: '미션', href: '/mission', icon: ExtensionIcon },
+  { label: '가족', href: '/family', icon: FaceIcon },
+  { label: '홈', href: '/home', isHome: true },
+  { label: '조르기', href: '/appeal', icon: SendMoneyIcon },
+  { label: 'MY', href: '/mypage', icon: PersonIcon },
+];
 
 const NavBar = () => {
   const pathname = usePathname();
 
-  const navItems: NavItem[] = useMemo(
-    () => [
-      { label: '홈', href: '/home', icon: HomeIcon },
-      { label: '정책', href: '/policy', icon: DocumentIcon },
-      { label: '알림', href: '/notification', icon: NotificationIcon },
-      { label: 'MY', href: '/mypage', icon: PersonIcon },
-    ],
-    [],
-  );
-
   return (
-    <nav className="fixed bottom-0 z-50 w-full bg-white shadow-[0_-1px_3px_rgba(0,0,0,0.1)] transition-all">
-      <ul className="flex h-15 w-full items-center justify-around pb-[env(safe-area-inset-bottom)]">
-        {navItems.map((item) => {
-          const isActive = item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
+    <nav className="fixed right-0 bottom-0 left-0 z-50 flex justify-center">
+      <div className="relative h-19 w-full">
+        <div className="absolute bottom-0 flex h-16 w-full items-center justify-between border-t border-gray-200 px-10 pb-[env(safe-area-inset-bottom)]">
+          {navItems.map((item) => {
+            if (item.isHome) {
+              return <div key="home-placeholder" className="w-8" />;
+            }
 
-          const Icon = item.icon;
+            const isActive = pathname === item.href;
+            const Icon = item.icon;
 
-          return (
-            <li key={item.href} className="flex-1">
+            return (
               <Link
+                key={item.href}
                 href={item.href}
-                className={`flex h-full flex-col items-center justify-center space-y-1 transition-opacity duration-200 hover:opacity-80 ${
-                  isActive ? 'text-primary-500' : 'text-gray-400'
-                }`}
-                aria-current={isActive ? 'page' : undefined}
+                className="flex flex-col items-center justify-center gap-2"
               >
-                <Icon
-                  sx={{
-                    fontSize: 24,
-                    color: 'inherit',
-                  }}
-                />
-
-                <span className="text-caption-m text-gray-700">{item.label}</span>
+                <div className="flex h-4 w-4 items-center justify-center">
+                  {Icon && (
+                    <Icon
+                      sx={{
+                        fontSize: 16,
+                        color: isActive ? 'var(--color-brand-black)' : 'var(--color-gray-700)',
+                      }}
+                    />
+                  )}
+                </div>
+                <span className="text-caption-m text-gray-700"> {item.label} </span>
               </Link>
-            </li>
-          );
-        })}
-      </ul>
+            );
+          })}
+        </div>
+
+        <Link
+          href="/home"
+          className="absolute top-0 left-1/2 flex h-13 w-13 -translate-x-1/2 items-center justify-center rounded-full"
+          style={{
+            background:
+              'linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), var(--color-brand-dark)',
+          }}
+        >
+          <HomeIcon width={17} height={19} className="text-white" />
+        </Link>
+      </div>
     </nav>
   );
 };

--- a/apps/service/src/components/common/NavBar.tsx
+++ b/apps/service/src/components/common/NavBar.tsx
@@ -8,8 +8,9 @@ import {
   Face as FaceIcon,
   Home as HomeIcon,
   PersonOutlined as PersonIcon,
-  SendOutlined as SendMoneyIcon,
+  Send as SendMoneyIcon,
 } from '@mui/icons-material';
+import { cn } from '@shared';
 
 const navItems = [
   { label: '미션', href: '/mission', icon: ExtensionIcon },
@@ -39,18 +40,21 @@ const NavBar = () => {
                 key={item.href}
                 href={item.href}
                 className="flex flex-col items-center justify-center gap-2"
+                aria-current={isActive ? 'page' : undefined}
               >
                 <div className="flex h-4 w-4 items-center justify-center">
                   {Icon && (
                     <Icon
                       sx={{
                         fontSize: 16,
-                        color: isActive ? 'var(--color-brand-black)' : 'var(--color-gray-700)',
+                        color: isActive ? 'var(--color-primary)' : 'var(--color-gray-700)',
                       }}
                     />
                   )}
                 </div>
-                <span className="text-caption-m text-gray-700"> {item.label} </span>
+                <span className={cn('text-caption-m', isActive ? 'text-primary' : 'text-gray-700')}>
+                  {item.label}
+                </span>
               </Link>
             );
           })}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #67 
- jira: DABOM-353

---

## 📝 변경 사항
- Header 컴포넌트 작성
  - HIDE_BACK_BTN_PATHS, HIDE_NOTI_BTN_PATHS로 백버튼 알람버튼에 쓸 페이지를 지정할 수 있습니다.
- NavBar 컴포넌트 작성

## 🎯 목적
- 디자인 시스템과의 시각적 일치성 확보

## 📂 적용 범위

- `src/components/common/Header.tsx`
- `src/components/common/NavBar.tsx`

---

## 📸 스크린샷
<img width="343" height="63" alt="스크린샷 2026-03-03 오후 9 47 29" src="https://github.com/user-attachments/assets/58eeb854-3153-4801-9b0f-19a4b588d643" />
<img width="343" height="63" alt="스크린샷 2026-03-03 오후 9 47 34" src="https://github.com/user-attachments/assets/bedfc221-ac64-46a2-8cf5-8926f7616f41" />
<img width="343" height="63" alt="스크린샷 2026-03-04 오전 9 41 09" src="https://github.com/user-attachments/assets/3847c446-9b66-4d04-bd5f-36228f64f67d" />
<img width="343" height="63" alt="스크린샷 2026-03-04 오전 9 41 11" src="https://github.com/user-attachments/assets/124ba8a0-3558-4ec5-943e-329d52f1285d" />



- 현재 Send Money가 적용이 안되어 추후 수정을 하겠습니다.

## 🖥️ 주요 코드 설명

```typescript
<Link
          href="/home"
          className="absolute top-0 left-1/2 flex h-13 w-13 -translate-x-1/2 items-center justify-center rounded-full"
          style={{
            background:
              'linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), var(--color-brand-dark)',
          }}
        >
          <HomeIcon width={17} height={19} className="text-white" />
        </Link>
```
- 메인 버튼은 Home 버튼은 피그마의 CSS 코드를 보면서 작성을 했습니다.

## 💬 리뷰어에게

- Header의 버튼 노출 상태가 기획과 일치하는지 확인 부탁드립니다.
- NavBar의 중앙 버튼이 모바일 뷰(390px)에서 정확히 중앙에 배치되는지 확인 부탁드립니다.

---

## 📋 체크리스트

- [x] Merge 대상 브랜치가 올바른가?
- [x] 코드가 정상적으로 빌드되는가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?
- [ ] 관련 테스트 코드를 작성했는가?
- [ ] 기존 테스트가 모두 통과하는가?
- [x] 코드 스타일을 준수하는가?

## 📌 참고 사항
- 
