### PR TITLE
[DABOM-388] not found, token expired 추가

### DIFF
--- a/apps/service/src/app/(beforeLogin)/login/page.tsx
+++ b/apps/service/src/app/(beforeLogin)/login/page.tsx
@@ -33,10 +33,10 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen justify-center">
-      <main className="flex flex-col justify-center">
-        <form onSubmit={(e) => handleLogin(e)} className="flex flex-col items-center">
-          <div className="flex flex-col gap-10">
+    <div className="flex min-h-screen items-center justify-center">
+      <main className="flex w-full flex-col items-center px-5">
+        <form onSubmit={(e) => handleLogin(e)} className="flex h-full flex-col items-center gap-30">
+          <div className="flex h-75 w-full flex-col gap-10">
             <InputField
               label="전화번호"
               type="tel"
@@ -66,7 +66,7 @@ export default function LoginPage() {
             )}
           </div>
 
-          <div className="mt-57 flex w-full justify-center">
+          <div className="flex w-full justify-center">
             <Button type="submit" size="lg" color="dark" disabled={isLoading}>
               로그인
             </Button>

--- a/apps/service/src/app/(beforeLogin)/login/page.tsx
+++ b/apps/service/src/app/(beforeLogin)/login/page.tsx
@@ -58,7 +58,7 @@ export default function LoginPage() {
 
             {isLoginFailed && (
               <div className="flex flex-row items-center justify-center gap-1">
-                <ErrorIcon className="text-negative h-3.5 w-3.5" />
+                <ErrorIcon sx={{ fontSize: 14 }} className="text-negative" />
                 <span className="text-body2-m text-negative">
                   아이디 또는 비밀번호가 일치하지 않습니다.
                 </span>

--- a/apps/service/src/app/expired/page.tsx
+++ b/apps/service/src/app/expired/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { Button, DaboIcon } from '@shared';
+
+export default function TokenExpiredPage() {
+  const router = useRouter();
+
+  const handleGoLogin = () => {
+    router.push('/login');
+  };
+
+  return (
+    <main className="flex h-dvh w-full flex-col items-center justify-center px-7.75">
+      <div className="flex flex-col items-center">
+        <DaboIcon type="hurt" />
+
+        <p className="text-body2-d mt-6 text-center">
+          세션이 만료되었어요.
+          <br />
+          다시 로그인해 주세요.
+        </p>
+
+        <div className="mt-29.5">
+          <Button type="button" size="lg" color="dark" onClick={handleGoLogin}>
+            로그인하러 가기
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/service/src/app/expired/page.tsx
+++ b/apps/service/src/app/expired/page.tsx
@@ -14,7 +14,7 @@ export default function TokenExpiredPage() {
   return (
     <main className="flex h-dvh w-full flex-col items-center justify-center px-7.75">
       <div className="flex flex-col items-center">
-        <DaboIcon type="hurt" />
+        <DaboIcon type="hurt" width={130} height={130} />
 
         <p className="text-body2-d mt-6 text-center">
           세션이 만료되었어요.

--- a/apps/service/src/app/not-found.tsx
+++ b/apps/service/src/app/not-found.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { Button, DaboIcon } from '@shared';
+
+export default function NotFound() {
+  const router = useRouter();
+
+  const handleGoHome = () => {
+    router.push('/home');
+  };
+
+  return (
+    <main className="flex h-dvh w-full flex-col items-center justify-center px-7.75">
+      <div className="flex flex-col items-center">
+        <DaboIcon type="hurt" />
+
+        <p className="text-body2-d mt-6 text-center">앗, 접근할 수 없는 페이지예요.</p>
+
+        <div className="mt-29.5">
+          <Button type="button" size="lg" color="dark" onClick={handleGoHome}>
+            홈으로 돌아가기
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/service/src/app/not-found.tsx
+++ b/apps/service/src/app/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
   return (
     <main className="flex h-dvh w-full flex-col items-center justify-center px-7.75">
       <div className="flex flex-col items-center">
-        <DaboIcon type="hurt" />
+        <DaboIcon type="hurt" width={130} height={130} />
 
         <p className="text-body2-d mt-6 text-center">앗, 접근할 수 없는 페이지예요.</p>
 

--- a/apps/service/src/app/offline/page.tsx
+++ b/apps/service/src/app/offline/page.tsx
@@ -10,7 +10,7 @@ export default function OfflinePage() {
   return (
     <main className="flex h-dvh w-full flex-col items-center justify-center px-7.75">
       <div className="flex flex-col items-center">
-        <DaboIcon type="hurt" />
+        <DaboIcon type="hurt" width={130} height={130} />
 
         <p className="text-body2-d mt-6 text-center">네트워크를 다시 확인해 주세요.</p>
 

--- a/packages/shared/src/utils/http.ts
+++ b/packages/shared/src/utils/http.ts
@@ -36,6 +36,18 @@ http.interceptors.response.use(
       const errorCode = data.error?.code;
       const serverMsg = data.error?.message;
 
+      if (
+        (errorCode === ERROR_CODES.AUTH_TOKEN_EXPIRED ||
+          errorCode === ERROR_CODES.AUTH_TOKEN_INVALID) &&
+        globalThis.window !== undefined
+      ) {
+        const currentPath = window.location.pathname;
+        if (currentPath !== '/expired' && currentPath !== '/login') {
+          localStorage.removeItem('access_token');
+          window.location.href = '/expired';
+        }
+      }
+
       const errorMessage =
         ERROR_MESSAGE_MAP[errorCode as keyof typeof ERROR_MESSAGE_MAP] ||
         serverMsg ||


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #86 
- jira: DABOM-388

---

## 📝 변경 사항
- not found 페이지 추가
- 세션 토큰 만료 페이지 추가
- 토큰 만료 시 /expired 자동 리더이렉트 추가
- login UI 수정

## 🎯 목적
- 시스템 예외 상황(404)에 대한 사용자 피드백 페이지 구축
- 토큰 만료 시 수동 로그아웃 없이 자동으로 세션 만료 페이지로 이동
- 로그인 페이지의 UI 수정

## 📂 적용 범위

- `packages/shared/src/utils/http.ts`
- `apps/service/src/app/not-found.tsx`
- `apps/service/src/app/expired/page.tsx`
- `apps/service/src/app/(beforeLogin)/login/page.tsx`
---

## 📸 스크린샷
<img width="362" height="788" alt="스크린샷 2026-03-09 오후 2 28 42" src="https://github.com/user-attachments/assets/b8bf359f-7bfc-497d-b664-bec84378cc07" />
<img width="362" height="788" alt="스크린샷 2026-03-09 오후 2 33 30" src="https://github.com/user-attachments/assets/29bde14f-a929-4ac6-a3b8-5bd256f4a843" />
<img width="362" height="788" alt="스크린샷 2026-03-09 오후 2 34 46" src="https://github.com/user-attachments/assets/427bb35e-5778-4bbb-a41a-d1d6edcd6dc8" />



## 🖥️ 주요 코드 설명

```typescript
if (
  (errorCode === ERROR_CODES.AUTH_TOKEN_EXPIRED ||
    errorCode === ERROR_CODES.AUTH_TOKEN_INVALID) &&
  globalThis.window !== undefined
) {
  const currentPath = window.location.pathname;
  if (currentPath !== '/expired' && currentPath !== '/login') {
    localStorage.removeItem('access_token');
    window.location.href = '/expired';
  }
}
```
- 토큰 만료 및 유효하지 않은 토큰 에러 감지 시 /expired 페이지로 자동 리다이렉트
## 💬 리뷰어에게
- 
## 📋 체크리스트

- [x] Merge 대상 브랜치가 올바른가?
- [x] 코드가 정상적으로 빌드되는가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?
- [x] 관련 테스트 코드를 작성했는가?
- [x] 기존 테스트가 모두 통과하는가?
- [x] 코드 스타일을 준수하는가?

## 📌 참고 사항
- 
